### PR TITLE
add getdetail, separate summary and response

### DIFF
--- a/back/summary/Gpt.py
+++ b/back/summary/Gpt.py
@@ -17,6 +17,16 @@ class Gpt:
         # Parameters for the API request
         self.model_engine = 'gpt-3.5-turbo'  # GPT-3.5 Turbo
 
+    def getsummary(self):
+        # Call the OpenAI GPT API and get the response
+        self.summary = openai.ChatCompletion.create(
+            model=self.model_engine,
+            messages=self.message,
+            # temperature=temperature,
+            max_tokens=self.max_tokens,
+        )
+        return self.summary
+    
     def getresponse(self):
         # Call the OpenAI GPT API and get the response
         self.response = openai.ChatCompletion.create(
@@ -41,24 +51,32 @@ class Gpt:
             {'role': 'user', 'content': f'Summarize the following article in 3 sentences : {text}'}]
 
     def raise_difficulty(self):
-        text = self.response['choices'][0]['message']['content']
+        text = self.summary['choices'][0]['message']['content']
         self.message = [
             {'role': 'user', 'content': f'Raise the difficulty of the vocabulary a little : {text}'}]
         return self.getresponse()
 
     def lower_difficulty(self):
-        text = self.response['choices'][0]['message']['content']
+        text = self.summary['choices'][0]['message']['content']
         self.message = [
             {'role': 'user', 'content': f'Lower the difficulty of the vocabulary a bit : {text}'}]
         return self.getresponse()
+    
+    def getdetail(self, keyword):
+        text = self.summary['choices'][0]['message']['content']
+        self.message = [
+            {'role': 'user', 'content': f'Find paragraphs related to {keyword} in {text}'}]
+            #{'role': 'user', 'content': f'Find one sentences related to {keyword} in {text}'}]
+        return self.getresponse()
 
 
+#Find paragraphs related to 'keyword'
 # Print the generated text from the response
 if (__name__ == '__main__'):
     g = Gpt()
     article = {'sections': [{'content': 'Monday marks the 25th anniversary of the Good Friday Agreement, which brought peace to Northern Ireland after a 30-year period of sectarian conflict known as the Troubles. Decades after the Irish War of Independence led to the island’s partition, the conflict escalated in the late 1960s, amid swelling anger at discrimination towards the province’s Irish Catholics. The IRA, mainly comprising Irish Catholics, sought to liberate the north from British rule and reunite it with the Republic of Ireland. This was opposed by the British Army and loyalist paramilitary groups such as the UDA and UVF, mainly comprising Protestants, who sought to keep Northern Ireland a part of the United Kingdom.'}]}
     g.setmessage(article)
-    res = g.getresponse()
+    res = g.getsummary()
     # print(res)
     # print()
     print(res['choices'][0]['message']['content'])
@@ -67,5 +85,8 @@ if (__name__ == '__main__'):
     print(res['choices'][0]['message']['content'])
     print()
     res = g.lower_difficulty()
-    res = g.lower_difficulty()
     print(res['choices'][0]['message']['content'])
+    print()
+    res = g.getdetail('dispute')
+    print(res['choices'][0]['message']['content'])
+    


### PR DESCRIPTION
기존에는 난이도 증가/감소를 호출하면 gpt.response가 덮어씌워지는 방식으로 작성되었음
summary와 response를 분리하여 기사 요약본은 다른 기능을 사용해도 항상 유지되도록 수정.

gpt.getdetail(keyword) 추가: gpt.summary에서 keyword와 관련된 문단 하나를 gpt.response에 넣고 반환함