### PR TITLE
Gpt

### DIFF
--- a/back/summary/Gpt.py
+++ b/back/summary/Gpt.py
@@ -29,7 +29,7 @@ class Gpt:
             elif (i>0):
                 prompt = [{'role': 'user', 'content': f'Summarize the following article in 3 sentences : {text} {self.message[i]}'}]
             self.summary = openai.ChatCompletion.create(
-                model=self.model_engine,
+                model = self.model_engine,
                 messages = prompt,
                 # temperature=temperature,
                 max_tokens=self.max_tokens,
@@ -39,26 +39,30 @@ class Gpt:
     # message set
     # def setmessage(self, type:str = 'sentences', number:int = 5, article: dict, max_tokens: int = 200, temprature: float = 0.5):
 
-    def setmessage(self, article: dict, max_tokens: int = 4000, temprature: float = 0.5):
+    def setmessage(self, article: dict, temprature: float = 0.5):
         # message to generate text from
         self.temperature = temprature
-        self.max_tokens = max_tokens
+        self.max_tokens = 0
         # message to generate text from
         text = ''
         self.message = []
         for d in article['sections']:
             text = text + d
-            if (self.checktoken(text) > max_tokens*0.8):
+            if (self.checktoken(text) > 3000):
+                if (self.max_tokens < 4000-self.checktoken(text)):
+                  self.max_tokens = 4000-self.checktoken(text)
                 self.message.append(text)
                 #self.prompt.append([{'role': 'user', 'content': f'Summarize the following article in 3 sentences : {text}'}])
                 text = ''
+        if (self.max_tokens < 4000-self.checktoken(text)):
+            self.max_tokens = 4000-self.checktoken(text)
         self.message.append(text)
 
     def high_difficulty(self):
         text = self.summary['choices'][0]['message']['content']
         self.highdiff = openai.ChatCompletion.create(
             model=self.model_engine,
-            messages=[{'role': 'user', 'content': f'Turn it into college-level vocabulary : {text}'}],
+            messages=[{'role': 'user', 'content': f'Change it to high school level vocabulary : {text}'}],
             # temperature=temperature,
             max_tokens=self.max_tokens,
         )
@@ -73,15 +77,30 @@ class Gpt:
             max_tokens=self.max_tokens,
         )
         return self.lowdiff
+      
+    def middle_difficulty(self):
+        text = self.summary['choices'][0]['message']['content']
+        self.middiff = openai.ChatCompletion.create(
+            model=self.model_engine,
+            messages=[{'role': 'user', 'content': f'Change it to middle school level vocabulary : {text}'}],
+            # temperature=temperature,
+            max_tokens=self.max_tokens,
+        )
+        return self.middiff
+
+    def all_response(self):
+      self.response = {'summary':self.getsummary(), 'low': self.low_difficulty(), 'high':self.high_difficulty(), 'mid':self.middle_difficulty()}
+      return self.response
+
 
 
 #Find paragraphs related to 'keyword'
 # Print the generated text from the response
 if (__name__ == '__main__'):
     g = Gpt()
-    article = {'sections': [{'content': 'Monday marks the 25th anniversary of the Good Friday Agreement, which brought peace to Northern Ireland after a 30-year period of sectarian conflict known as the Troubles. Decades after the Irish War of Independence led to the island’s partition, the conflict escalated in the late 1960s, amid swelling anger at discrimination towards the province’s Irish Catholics. The IRA, mainly comprising Irish Catholics, sought to liberate the north from British rule and reunite it with the Republic of Ireland. This was opposed by the British Army and loyalist paramilitary groups such as the UDA and UVF, mainly comprising Protestants, who sought to keep Northern Ireland a part of the United Kingdom.'}]}
+    article = {'sections': ['Monday marks the 25th anniversary of the Good Friday Agreement, which brought peace to Northern Ireland after a 30-year period of sectarian conflict known as the Troubles. Decades after the Irish War of Independence led to the island\'s partition, the conflict escalated in the late 1960s, amid swelling anger at discrimination towards the province\'s Irish Catholics. The IRA, mainly comprising Irish Catholics, sought to liberate the north from British rule and reunite it with the Republic of Ireland. This was opposed by the British Army and loyalist paramilitary groups such as the UDA and UVF, mainly comprising Protestants, who sought to keep Northern Ireland a part of the United Kingdom.']}
     g.setmessage(article)
-    res = g.getsummary()
+    res = g.all_response()
     print(res)
     # print()
     '''


### PR DESCRIPTION
token 조절 기능 추가: 토큰의 80%이상을 사용하면 한번 요약 후 남은 기사 입력
난이도 조절을 상대적인 수준이 아닌 초등학교/원문/대학교 수준으로 변경
변경된 article구조에 맞게 코드 변경
